### PR TITLE
perf(backend): upgrade wshub-core to current version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	</modules>
 
 	<properties>
-		<ch.cern.eam.eam-wshub-core.version>12.1.5-8</ch.cern.eam.eam-wshub-core.version>
+		<ch.cern.eam.eam-wshub-core.version>12.1-16-8</ch.cern.eam.eam-wshub-core.version>
 		<ch.cern.cmms.eamtools.version>2.4.3</ch.cern.cmms.eamtools.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/wshubejb/src/main/java/ch/cern/cmms/wshub/beans/WSHub.java
+++ b/wshubejb/src/main/java/ch/cern/cmms/wshub/beans/WSHub.java
@@ -8,7 +8,6 @@ import javax.jws.WebResult;
 import javax.jws.WebService;
 
 import ch.cern.cmms.wshub.misc.GasWorkOrder;
-import ch.cern.eam.wshub.core.client.InforContext;
 import ch.cern.eam.wshub.core.services.administration.entities.EAMUser;
 import ch.cern.eam.wshub.core.services.administration.entities.MenuSpecification;
 import ch.cern.eam.wshub.core.services.comments.entities.Comment;
@@ -16,7 +15,6 @@ import ch.cern.eam.wshub.core.services.entities.*;
 import ch.cern.eam.wshub.core.services.equipment.entities.*;
 import ch.cern.eam.wshub.core.services.material.entities.*;
 import ch.cern.eam.wshub.core.services.userdefinedscreens.entities.UDTOpBean;
-import ch.cern.eam.wshub.core.services.userdefinedscreens.entities.UDTRow;
 import ch.cern.eam.wshub.core.services.workorders.entities.*;
 import ch.cern.eam.wshub.core.services.entities.BatchResponse;
 import ch.cern.cmms.wshub.entities.AsyncExecution;
@@ -35,7 +33,7 @@ import ch.cern.eam.wshub.core.services.workorders.entities.Activity;
 import ch.cern.eam.wshub.core.services.workorders.entities.Aspect;
 import ch.cern.eam.wshub.core.services.workorders.entities.InforCaseTask;
 import ch.cern.eam.wshub.core.services.workorders.entities.TaskplanCheckList;
-import ch.cern.eam.wshub.core.services.workorders.entities.WorkOrderActivityCheckList;
+import ch.cern.eam.wshub.core.services.workorders.entities.WorkOrderActivityChecklistItem;
 
 @Local
 @WebService(targetNamespace = "http://cern.ch/cmms/infor/wshub", name = "InforWSPortType")
@@ -141,8 +139,9 @@ public interface WSHub {
 			throws InforException;
 
 	public String updateWorkOrderChecklists(
-			@WebParam(name = "workOrderChecklist") WorkOrderActivityCheckList WorkOrderChecklist,
-			@WebParam(name = "credentials") Credentials credentials, @WebParam(name = "sessionID") String sessionID)
+			@WebParam(name = "workOrderChecklist") WorkOrderActivityChecklistItem WorkOrderChecklist,
+            @WebParam(name = "taskPlan") TaskPlan taskPlan, @WebParam(name = "credentials") Credentials credentials,
+            @WebParam(name = "sessionID") String sessionID)
 			throws InforException;
 
 	public String createRouteEquipment(@WebParam(name = "routeEquipment") RouteEquipment routeEquipment,

--- a/wshubejb/src/main/java/ch/cern/cmms/wshub/beans/WSHubBean.java
+++ b/wshubejb/src/main/java/ch/cern/cmms/wshub/beans/WSHubBean.java
@@ -224,12 +224,12 @@ public class WSHubBean implements WSHub {
 		return inforClient.getWorkOrderMiscService().createTaskPlan(inforClient.getTools().getInforContext(credentials, sessionID), taskPlan);
 	}
 
-	public WorkOrderActivityCheckList[] readWOActivityChecklists(Activity activity, Credentials credentials, String sessionID) throws InforException {
-		return inforClient.getChecklistService().readWorkOrderChecklists(inforClient.getTools().getInforContext(credentials, sessionID), activity);
+	public WorkOrderActivityChecklistItem[] readWOActivityChecklists(Activity activity, Credentials credentials, String sessionID) throws InforException {
+		return inforClient.getChecklistService().readWorkOrderChecklistItems(inforClient.getTools().getInforContext(credentials, sessionID), activity);
 	}
 
-	public String updateWorkOrderChecklists(WorkOrderActivityCheckList WorkOrderChecklist, Credentials credentials, String sessionID) throws InforException {
-		return inforClient.getChecklistService().updateWorkOrderChecklist(inforClient.getTools().getInforContext(credentials, sessionID), WorkOrderChecklist);
+	public String updateWorkOrderChecklists(WorkOrderActivityChecklistItem WorkOrderChecklist, TaskPlan taskPlan, Credentials credentials, String sessionID) throws InforException {
+		return inforClient.getChecklistService().updateWorkOrderChecklistItem(inforClient.getTools().getInforContext(credentials, sessionID), WorkOrderChecklist, taskPlan);
 	}
 
 	public String createRouteEquipment(RouteEquipment routeEquipment, Credentials credentials, String sessionID) throws InforException {

--- a/wshubrest/src/main/java/ch/cern/cmms/wshub/rest/controllers/Grid.java
+++ b/wshubrest/src/main/java/ch/cern/cmms/wshub/rest/controllers/Grid.java
@@ -58,7 +58,7 @@ public class Grid extends WSHubController {
 			gridRequest.setGridName(gridName);
 			GridRequestResult gridRequestResult = inforClient.getGridsService().executeQuery(authentication.getInforContext(), gridRequest);
 			LinkedList<LinkedHashMap<String, String>> collect = Arrays.stream(gridRequestResult.getRows())
-					.map(row -> GridTools.gridRequestRowMapper(row, null))
+					.map(row -> GridTools.gridRequestRowMapper(row, null, false))
 					.collect(Collectors.toCollection(LinkedList::new));
 			return ok(collect);
 		} catch (InforException e) {


### PR DESCRIPTION
BREAKING CHANGE:
`updateWorkOrderChecklists()` in wshubejb's WSHub bean now expects the task plan as an argument.